### PR TITLE
Wait for server to acknowledge message sending

### DIFF
--- a/examples/cli.php
+++ b/examples/cli.php
@@ -275,6 +275,8 @@ if (isset($argv[1])){
                 try{
                     $w = initiateConnection($username, $nickname, $password, $debug);
                     $w->sendMessage($target , $msg);
+                    // wait for server to acknowledge that a message has been sent!
+                    while($w->pollMessage());
                     echo "\n";
                     echo json_encode($output);
                 } catch (Exception $e) {


### PR DESCRIPTION
After a message has been sent, if the script just dies nothing gets sent, and that means no message is actually sent, this has to be extended to other sending methods (taken outside of the switch case maybe) originally turning the entire thing into a daemon would be more effective so that it just logs in once and stays alive :)
